### PR TITLE
Add Gazebo flag metal shaders

### DIFF
--- a/garden_demo/models/Gazebo flag/materials/programs/flag_fs.metal
+++ b/garden_demo/models/Gazebo flag/materials/programs/flag_fs.metal
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct Params
+{
+  float3 light_dir;
+};
+
+struct PS_INPUT
+{
+  float3 pos;
+  float3 norm;
+  float2 texUv;
+  float flip;
+};
+
+fragment float4 main_metal
+(
+  PS_INPUT inPs [[stage_in]],
+  texture2d<float> texMap [[texture(0)]],
+  sampler texMapSampler [[sampler(0)]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  float3 lightAmbient = float3(0.1f, 0.1f, 0.1f);
+  float3 lightDiffuse = float3(0.7f, 0.7f, 0.7f);
+  float3 lightSpecular = float3(0.1f, 0.1f, 0.1f);
+
+  float3 color = float3(0.8, 0.8, 0.8);
+  float3 ambientColor = color * 0.5;
+  float3 diffuseColor = texMap.sample(texMapSampler, inPs.texUv.xy).xyz;
+  float3 specularColor = color;
+
+  float3 lightDir = normalize(p.light_dir);
+  if (inPs.flip > 0)
+  {
+    // not ideal but make sure the other side is always lit
+    lightDir = -lightDir;
+  }
+
+  // normalize both input floattors
+  float3 n = normalize(inPs.norm);
+  float3 e = normalize(-inPs.pos);
+
+  float specular = 0.0f;
+  float NdotL = max(dot(lightDir, inPs.norm), 0.0);
+  // if the vertex is lit compute the specular color
+  if (NdotL> 0.0)
+  {
+    // compute the half floattor
+    float3 halfVector = normalize(lightDir + e);
+
+    // add specular
+    float NdotH = max(dot(halfVector, n), 0.0);
+
+    float shininess = 10.0;
+    specular = pow(NdotH, shininess);
+  }
+
+  float3 finalColor = lightAmbient * ambientColor;
+  finalColor += lightDiffuse * diffuseColor * NdotL;
+  finalColor += lightSpecular * specularColor * specular;
+
+  // account for gamma correction
+  finalColor = finalColor * finalColor;
+
+  return float4(finalColor, 1.0);
+}

--- a/garden_demo/models/Gazebo flag/materials/programs/flag_vs.metal
+++ b/garden_demo/models/Gazebo flag/materials/programs/flag_vs.metal
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct VS_INPUT
+{
+  float4 position [[attribute(VES_POSITION)]];
+  float2 uv0 [[attribute(VES_TEXTURE_COORDINATES0)]];
+};
+
+struct Params
+{
+  // time
+  float t;
+  float4x4 worldview_matrix;
+  float4x4 worldviewproj_matrix;
+  float4x4 inverse_transpose_world_matrix;
+  float amplitude;
+  float speed;
+  float frequency;
+  float2 size;
+  // the flag is composed of two meshes. One with flipped normals.
+  // Here we need to change the shaders logic for deforming vertices and
+  // computing deformed normals
+  // 1 to flip vertex deformation and normal
+  int flip;
+};
+
+struct PS_INPUT
+{
+  float4 gl_Position [[position]];
+  float3 pos;
+  float3 norm;
+  float2 texUv;
+  float flip;
+};
+
+float4 deform(float4 v, float2 uv, float speed, float frequency, float amplitude, float t)
+{
+  // requires flag mesh to be facing z direction
+  v.z += sin((uv.x - t * speed) * frequency) * amplitude * uv.x;
+  v.x += cos((uv.y - t * speed) * frequency) * amplitude*0.3 * uv.x;
+  return v;
+}
+
+vertex PS_INPUT main_metal
+(
+  VS_INPUT input [[stage_in]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  PS_INPUT outVs;
+
+  // flip vertex deformation and normal calculation if needed
+  float2 uv = input.uv0.xy;
+  float incr = 1.0;
+  if (p.flip > 0)
+  {
+    uv = float2(1 - uv.x, uv.y);
+    incr = -1.0;
+  }
+  float4 v = deform(input.position, uv,
+      p.speed, p.frequency, p.amplitude, p.t);
+
+  // compute deformed normal
+  float4 vertexX = float4((uv.x + (0.01*incr) - 0.5) * p.size.x, input.position.yzw);
+  float4 vertexY = float4(input.position.x, (uv.y + 0.01 - 0.5) * -p.size.y, input.position.zw);
+  float4 va = deform(vertexX, float2(uv.x + (0.01 * incr), uv.y),
+      p.speed, p.frequency, p.amplitude, p.t);
+  float4 vb = deform(vertexY, float2(uv.x, uv.y + 0.01),
+      p.speed, p.frequency, p.amplitude, p.t);
+  float3 norm = cross(normalize(vb.xyz - v.xyz), normalize(va.xyz - v.xyz));
+  norm = normalize(norm);
+
+  outVs.gl_Position = p.worldviewproj_matrix * v;
+
+  float4 pos = p.worldview_matrix * v;
+  outVs.pos = pos.xyz / pos.w;
+  outVs.norm = float3((p.inverse_transpose_world_matrix) * float4(norm, 1.0));
+  outVs.texUv = input.uv0.xy;
+  outVs.flip = p.flip;
+
+  return outVs;
+}
+

--- a/garden_demo/models/Gazebo flag/model.sdf
+++ b/garden_demo/models/Gazebo flag/model.sdf
@@ -71,6 +71,10 @@
             <vertex>materials/programs/flag_vs_330.glsl</vertex>
             <fragment>materials/programs/flag_fs_330.glsl</fragment>
           </shader>
+          <shader language="metal">
+            <vertex>materials/programs/flag_vs.metal</vertex>
+            <fragment>materials/programs/flag_fs.metal</fragment>
+          </shader>
           <param>
             <shader>vertex</shader>
             <name>worldviewproj_matrix</name>
@@ -139,10 +143,14 @@
             <uri>meshes/flag2cr.dae</uri>
           </mesh>
         </geometry>
-        <plugin filename="ignition-gazebo-shader-param-system" name="ignition::gazebo::systems::ShaderParam">
+        <plugin filename="gz-sim-shader-param-system" name="gz::sim::systems::ShaderParam">
           <shader language="glsl">
             <vertex>materials/programs/flag_vs_330.glsl</vertex>
             <fragment>materials/programs/flag_fs_330.glsl</fragment>
+          </shader>
+          <shader language="metal">
+            <vertex>materials/programs/flag_vs.metal</vertex>
+            <fragment>materials/programs/flag_fs.metal</fragment>
           </shader>
           <param>
             <shader>vertex</shader>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

# 🎉 New feature

depends on https://github.com/gazebosim/gz-sim/pull/1713

## Summary

Added Gazebo flag metal shaders


## Test it

launch the demo on mac and you should see:

<img width="1112" alt="Screen Shot 2022-09-15 at 3 59 10 PM" src="https://user-images.githubusercontent.com/4000684/190524443-bfc11cc3-e434-43a7-ba0e-96da45f4f094.png">


