### PR TITLE
Add simslides functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone https://github.com/gazebosim/garden_demo
 
 export GZ_SIM_RESOURCE_PATH=`pwd`/garden_demo/models:$GZ_SIM_RESOURCE_PATH
 
-gz sim -v 4 "garden_demo/garden.sdf"
+gz sim -v 4 -r "garden_demo/garden.sdf"
 ```
 
 ---
@@ -27,10 +27,10 @@ colcon build --merge-install --packages-select simslides
 
 export GZ_GUI_PLUGIN_PATH=`pwd`/install/lib/simslides/gz-gui/:$GZ_GUI_PLUGIN_PATH
 
-gz sim -v 4 "garden_demo/garden.sdf"
+gz sim -v 4 -r "garden_demo/garden.sdf"
 ```
 
 Keyboard keys:
 * Left arrow key: go back
 * Right arrow key: advance
-* F1 key: re-position 
+* F1 key: re-position

--- a/garden_demo/garden.sdf
+++ b/garden_demo/garden.sdf
@@ -304,6 +304,9 @@
 
         <!-- floating ball (michel) -->
         <keyframe type='cam_pose' pose="54.112648 9.684307 19.904329 0 0.551025 -0.703802"/>
+
+        <!-- reset & mujoco (michael caroll then addisu) -->
+        <keyframe type='cam_pose' pose="-68.208305 3.722506 19.806673 0.1938373 0.576818 -2.835106"/>
       </plugin>
 
     </gui>


### PR DESCRIPTION
Since this is a large demo and sometimes zooming/panning can take awhile, I thought it might help the presenter use the `simslides` functionality to move the gui camera around to certain places or reposition the camera to the last set location. 

I'm leaving this as a PR for now so that others who are adding their demos don't have to get `simslides` set up. I'll add more camera positions as they are needed.

![resized](https://user-images.githubusercontent.com/8602001/190830358-02e06af3-70dc-40b8-81fa-128d165ffed8.gif)
